### PR TITLE
label offset added

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,11 +24,10 @@ class _MyGaugeExampleState extends State<MyGaugeExample> {
               child: LinearGauge(
                 value: 75.0,
                 labelStyle: LabelStyle(
-                  fontSize: 10,
-                  color: Colors.red,
-                  rulerPosition: RulerPosition.top,
-
-                ),
+                    fontSize: 10,
+                    color: Colors.red,
+                    rulerPosition: RulerPosition.top,
+                    labelOffset: 20),
                 primaryRulerColor: Colors.red,
                 indicator: LinearGaugeIndicator(
                   shape: PointerShape.circle,

--- a/lib/linear_gauge/linear_gauge.dart
+++ b/lib/linear_gauge/linear_gauge.dart
@@ -202,6 +202,9 @@ class LinearGauge extends LeafRenderObjectWidget {
   final double? secondaryRulersWidth;
 
   ///
+  /// `Warning`:`deprecated`
+  ///
+  /// use `labelOffset` property in `labelStyle` to set gap b/w label & primary ruler
   ///
   /// `labelTopMargin` sets the margin from the  top of the label
   ///
@@ -215,6 +218,7 @@ class LinearGauge extends LeafRenderObjectWidget {
   /// ),
   /// ```
   ///
+
   final double? labelTopMargin;
 
   ///
@@ -357,6 +361,7 @@ class LinearGauge extends LeafRenderObjectWidget {
         labelColor: labelStyle!.color!,
         showLabel: labelStyle!.showLabel!,
         rulerPosition: labelStyle!.rulerPosition!,
+        labelOffset: labelStyle!.labelOffset!,
         showSecondaryRulers: showSecondaryRulers,
         showPrimaryRulers: showPrimaryRulers,
         indicator: indicator!,
@@ -389,6 +394,7 @@ class LinearGauge extends LeafRenderObjectWidget {
       ..setLabelColor = labelStyle!.color!
       ..setShowLabel = labelStyle!.showLabel!
       ..setRulerPosition = labelStyle!.rulerPosition!
+      ..setLabelOffset = labelStyle!.labelOffset!
       ..setShowSecondaryRulers = showSecondaryRulers
       ..setShowPrimaryRulers = showPrimaryRulers
       ..setValue = value!

--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -30,6 +30,7 @@ class RenderLinearGauge extends RenderBox {
     required Color labelColor,
     required bool showLabel,
     required RulerPosition rulerPosition,
+    required double labelOffset,
     required bool showSecondaryRulers,
     required bool showPrimaryRulers,
     required double value,
@@ -55,6 +56,7 @@ class RenderLinearGauge extends RenderBox {
         _labelColor = labelColor,
         _showLabel = showLabel,
         _rulerPosition = rulerPosition,
+        _labelOffset = labelOffset,
         _showSecondaryRulers = showSecondaryRulers,
         _showPrimaryRulers = showPrimaryRulers,
         _value = value,
@@ -332,6 +334,14 @@ class RenderLinearGauge extends RenderBox {
     markNeedsPaint();
   }
 
+  double get getLabelOffset => _labelOffset;
+  double _labelOffset;
+  set setLabelOffset(double val) {
+    if (_labelOffset == val) return;
+    _labelOffset = val;
+    markNeedsPaint();
+  }
+
   bool get showSecondaryRulers => _showSecondaryRulers;
   bool _showSecondaryRulers;
   set setShowSecondaryRulers(bool val) {
@@ -420,26 +430,29 @@ class RenderLinearGauge extends RenderBox {
 
     paragraph.layout(ui.ParagraphConstraints(width: labelSize.width));
 
-    Offset labelOffsets;
+    // offset for drawing the label on the canvas
+    Offset labelPosition;
 
     switch (rulerPosition) {
       case RulerPosition.top:
-        labelOffsets = Offset(
+        labelPosition = Offset(
           (list[0].dx - (labelSize.width / 2)),
-          -(getPrimaryRulersHeight + labelSize.height - 2),
+          -(getPrimaryRulersHeight + getLabelOffset + labelSize.height - 2),
         );
         break;
       default:
-        labelOffsets = Offset(
+        double labelOffset =
+            (getLabelTopMargin == 0.0) ? getLabelOffset : getLabelTopMargin;
+        labelPosition = Offset(
           (list[0].dx - (labelSize.width / 2)),
-          (list[0].dy + getPrimaryRulersHeight + getLabelTopMargin),
+          (list[0].dy + getPrimaryRulersHeight + labelOffset),
         );
         break;
     }
 
     canvas.drawParagraph(
       paragraph,
-      labelOffsets,
+      labelPosition,
     );
   }
 
@@ -568,7 +581,6 @@ class RenderLinearGauge extends RenderBox {
 
       Offset a = Offset(x, y);
 
-
       canvas.drawLine(primaryRulerStartPoint, a, _primaryRulersPaint);
       if (showLabel) {
         _drawLabels(canvas, key, value);
@@ -585,7 +597,6 @@ class RenderLinearGauge extends RenderBox {
         rulerPosition,
         getLinearGaugeBoxDecoration.height,
         _indicator);
-
   }
 
   void _setPrimaryRulersPaint() {
@@ -642,7 +653,6 @@ class RenderLinearGauge extends RenderBox {
     if (showSecondaryRulers) {
       _drawSecondaryRulers(canvas);
     }
-
 
     if (rulerPosition != RulerPosition.center) {
       if (getShowLinearGaugeContainer) {

--- a/lib/linear_gauge/styles/linear_gauge_label_style.dart
+++ b/lib/linear_gauge/styles/linear_gauge_label_style.dart
@@ -7,6 +7,7 @@ class LabelStyle {
     this.color = Colors.black,
     this.showLabel = true,
     this.rulerPosition = RulerPosition.bottom,
+    this.labelOffset = 0,
   });
 
   ///
@@ -40,4 +41,19 @@ class LabelStyle {
   ///
 
   final RulerPosition? rulerPosition;
+
+  ///
+  /// `labelOffset` Sets the gap of the label from the primary ruler
+  ///
+  /// default is to `labelOffset = 0.0
+  ///
+  /// Example
+  ///
+  ///  ```dart
+  /// child: const LabelStyle(
+  ///   labelOffset: 10.0,
+  /// ),
+  /// ```
+  ///
+  final double? labelOffset;
 }


### PR DESCRIPTION
- added deprecated comment for labelTopMargin
<img width="702" alt="Screenshot 2023-02-28 at 5 58 47 PM" src="https://user-images.githubusercontent.com/126167018/221855235-631781bd-0d35-4ae0-9e74-0a24c28020fb.png">

- added labelOffset property in labelStyle.
this was the output 
<img width="982" alt="Screenshot 2023-02-28 at 5 59 55 PM" src="https://user-images.githubusercontent.com/126167018/221855515-55901642-6e92-4a6d-a255-5a8f9661e7ca.png">

- if user gives labelTopMargin when rulerPosition is bottom or center then labelTopMargin is used over labelOffset(in line 444 )

<img width="838" alt="Screenshot 2023-02-28 at 6 00 44 PM" src="https://user-images.githubusercontent.com/126167018/221855907-f19afd68-4067-4b01-8ecf-8e054fd4573f.png">

-in case of rulerPosition top it works fine



