### PR TITLE
Feat range colors to labels

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:geekyants_flutter_gauges/gauges.dart';
 
 void main() {
-  runApp(const MaterialApp(home: MyGaugeExample()));
+  runApp(const MaterialApp(
+      debugShowCheckedModeBanner: false, home: MyGaugeExample()));
 }
 
 class MyGaugeExample extends StatefulWidget {
@@ -16,22 +17,23 @@ class _MyGaugeExampleState extends State<MyGaugeExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xff1e1e1e),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             SizedBox(
               child: LinearGauge(
-                  // rulers: ,
-                  rangeLinearGauge: [
-                    RangeLinearGauge(color: Colors.blue, start: 0, end: 10),
-                    RangeLinearGauge(color: Colors.green, start: 10, end: 25),
-                    RangeLinearGauge(color: Colors.orange, start: 25, end: 35),
-                    RangeLinearGauge(color: Colors.yellow, start: 35, end: 50),
-                    RangeLinearGauge(color: Colors.purple, start: 50, end: 75),
-                    RangeLinearGauge(color: Colors.red, start: 75, end: 100)
-                  ]),
+                value: 60,
+                indicator: LinearGaugeIndicator(shape: PointerShape.circle),
+                linearGaugeBoxDecoration: LinearGaugeBoxDecoration(),
+                rangeLinearGauge: [
+                  RangeLinearGauge(color: Colors.green, start: 0, end: 10),
+                  RangeLinearGauge(color: Colors.yellow, start: 10, end: 25),
+                  RangeLinearGauge(color: Colors.amber, start: 25, end: 50),
+                  RangeLinearGauge(color: Colors.blue, start: 50, end: 75),
+                  RangeLinearGauge(color: Colors.red, start: 75, end: 100)
+                ],
+              ),
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ class _MyGaugeExampleState extends State<MyGaugeExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: const Color(0xff1e1e1e),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,19 +16,25 @@ class MyGaugeExample extends StatefulWidget {
 class _MyGaugeExampleState extends State<MyGaugeExample> {
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             SizedBox(
               child: LinearGauge(
-                start: 10,
-                end: 50,
-                value: 25,
-                indicator: LinearGaugeIndicator(shape: PointerShape.circle),
-                linearGaugeBoxDecoration: LinearGaugeBoxDecoration(),
-              ),
+                  start: 10,
+                  end: 50,
+                  value: 50,
+                  indicator: const LinearGaugeIndicator(
+                    shape: PointerShape.triangle,
+                  ),
+                  rulers: const RulerStyle(),
+                  rangeLinearGauge: [
+                    RangeLinearGauge(color: Colors.blue, start: 10, end: 20),
+                    RangeLinearGauge(color: Colors.green, start: 20, end: 30),
+                    RangeLinearGauge(color: Colors.orange, start: 30, end: 50),
+                  ]),
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,23 +16,18 @@ class MyGaugeExample extends StatefulWidget {
 class _MyGaugeExampleState extends State<MyGaugeExample> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return const Scaffold(
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             SizedBox(
               child: LinearGauge(
-                value: 60,
+                start: 10,
+                end: 50,
+                value: 25,
                 indicator: LinearGaugeIndicator(shape: PointerShape.circle),
                 linearGaugeBoxDecoration: LinearGaugeBoxDecoration(),
-                rangeLinearGauge: [
-                  RangeLinearGauge(color: Colors.green, start: 0, end: 10),
-                  RangeLinearGauge(color: Colors.yellow, start: 10, end: 25),
-                  RangeLinearGauge(color: Colors.amber, start: 25, end: 50),
-                  RangeLinearGauge(color: Colors.blue, start: 50, end: 75),
-                  RangeLinearGauge(color: Colors.red, start: 75, end: 100)
-                ],
               ),
             ),
           ],

--- a/lib/linear_gauge/linear_gauge.dart
+++ b/lib/linear_gauge/linear_gauge.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:geekyants_flutter_gauges/gauges.dart';
 import 'linear_gauge_painter.dart';
-import './range_linear_gauge/range_linear_gauge.dart';
 
 class LinearGauge extends LeafRenderObjectWidget {
   ///
@@ -34,7 +33,7 @@ class LinearGauge extends LeafRenderObjectWidget {
       shape: PointerShape.circle,
     ),
     this.rulers = const RulerStyle(),
-    this.rangeLinearGauge,
+    this.rangeLinearGauge = const [],
   }) : super(key: key);
 
   ///

--- a/lib/linear_gauge/linear_gauge.dart
+++ b/lib/linear_gauge/linear_gauge.dart
@@ -29,9 +29,7 @@ class LinearGauge extends LeafRenderObjectWidget {
     this.showLinearGaugeContainer = true,
     this.linearGaugeBoxDecoration = const LinearGaugeBoxDecoration(),
     this.labelTopMargin = 0.0,
-    this.indicator = const LinearGaugeIndicator(
-      shape: PointerShape.circle,
-    ),
+    this.indicator = const LinearGaugeIndicator(),
     this.rulers = const RulerStyle(),
     this.rangeLinearGauge = const [],
   }) : super(key: key);

--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -482,6 +482,13 @@ class RenderLinearGauge extends RenderBox {
   }
 
   void _paintGaugeContainer(Canvas canvas, Size size) {
+    if (rangeLinearGauge!.isNotEmpty) {
+      assert(rangeLinearGauge!.last.end <= getEnd,
+          'The end value of the range should be less than the end value of the gauge.');
+      assert(rangeLinearGauge!.first.start >= getStart,
+          'The start value of the range should be less than the start value of the gauge.');
+    }
+
     Offset offset = const Offset(0, 0);
     late double end;
     late double start;
@@ -569,7 +576,7 @@ class RenderLinearGauge extends RenderBox {
         _linearGaugeContainerValuePaint,
       );
 
-      /// For loop for calculating colors in [Linear-Gauge-Color]
+      /// For loop for calculating colors in [RangeLinearGauge]
       for (int i = 0; i < rangeLinearGauge!.length; i++) {
         // Method to cal exact width
         double calculateValuePixelWidth(double value) {
@@ -587,8 +594,11 @@ class RenderLinearGauge extends RenderBox {
                 calculateValuePixelWidth(rangeLinearGauge![i].start);
 
         _linearGaugeContainerValuePaint.color = rangeLinearGauge![i].color;
-        gaugeContainer = Rect.fromLTWH(colorRangeStart, offset.dy,
-            colorRangeWidth, getLinearGaugeBoxDecoration.height);
+        // gaugeContainer = Rect.fromLTWH(colorRangeStart, offset.dy,
+        //     colorRangeWidth, getLinearGaugeBoxDecoration.height);
+
+        gaugeContainer = Rect.fromLTWH(start, offset.dy, totalValOnPixel,
+            getLinearGaugeBoxDecoration.height);
         _linearGaugeContainerValuePaint.color = rangeLinearGauge![i].color;
         canvas.drawRect(
           gaugeContainer,
@@ -736,8 +746,10 @@ class RenderLinearGauge extends RenderBox {
       _indicator.setPointerValue = value;
     }
 
-    var firstOff =
-        _linearGaugeLabel.getPrimaryRulersOffset["0"]![0] + firstOffset;
+    print(firstOffset);
+    var firstOff = _linearGaugeLabel
+            .getPrimaryRulersOffset[getStart.toInt().toString()]![0] +
+        firstOffset;
 
     getLinearGaugeIndicator.drawPointer(
         _indicator.shape!, canvas, firstOff, this);

--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -123,7 +123,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [textStyle] parameter.
+  /// Getter and Setter for the [_textStyle] parameter.
   ///
   get getTextStyle => _textStyle;
   TextStyle _textStyle;
@@ -135,7 +135,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [primaryRulersWidth] parameter.
+  /// Getter and Setter for the [_primaryRulersWidth] parameter.
   ///
   get getPrimaryRulersWidth => _primaryRulersWidth;
   double _primaryRulersWidth;
@@ -147,7 +147,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [primaryRulersHeight] parameter.
+  /// Getter and Setter for the [_primaryRulersHeight] parameter.
   ///
   get getPrimaryRulersHeight => _primaryRulersHeight;
 
@@ -161,8 +161,9 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [secondaryRulersHeight] parameter.
+  /// Getter and Setter for the [_secondaryRulersHeight] parameter.
   ///
+
   get getSecondaryRulersHeight => _secondaryRulersHeight;
 
   double _secondaryRulersHeight;
@@ -175,9 +176,8 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [secondaryRulersWidth] parameter.
+  /// Getter and Setter for the [_secondaryRulersWidth] parameter.
   ///
-
   get getSecondaryRulersWidth => _secondaryRulersWidth;
   double _secondaryRulersWidth;
   set setSecondaryRulersWidth(secondaryRulersWidth) {
@@ -188,7 +188,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [LinearGaugeIndicator] parameter.
+  /// Getter and Setter for the [_indicator] parameter.
   ///
   LinearGaugeIndicator get getLinearGaugeIndicator => _indicator;
   LinearGaugeIndicator _indicator;
@@ -213,7 +213,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  /// Getter and Setter for the [primaryRulerColor] parameter.
+  /// Getter and Setter for the [_primaryRulerColor] parameter.
   ///
   Color get getPrimaryRulerColor => _primaryRulerColor;
   Color _primaryRulerColor;
@@ -250,7 +250,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  ///
+  /// Getter and Setter for the [SecondaryRulerPerInterval] parameter.
   ///
   double get getSecondaryRulerPerInterval => _secondaryRulerPerInterval;
   double _secondaryRulerPerInterval;
@@ -264,7 +264,7 @@ class RenderLinearGauge extends RenderBox {
   }
 
   ///
-  ///
+  /// Getter and Setter for the [LinearGaugeContainerBgColor] parameter.
   ///
   Color get getLinearGaugeContainerBgColor => _linearGaugeContainerBgColor;
   Color _linearGaugeContainerBgColor;
@@ -397,15 +397,32 @@ class RenderLinearGauge extends RenderBox {
         _indicator);
   }
 
-  void _drawLabels(Canvas canvas, String text, List<Offset> list) {
+  void _drawLabels(
+    Canvas canvas,
+    String text,
+    List<Offset> list,
+  ) {
     final ui.ParagraphStyle paragraphStyle = ui.ParagraphStyle(
       textDirection: TextDirection.ltr,
     );
     final String labelText = text;
     final double? value = double.tryParse(text);
 
+    // calculator method to get the text style based on the range
+    Color getRangeColor(String text) {
+      for (int i = 0; i < rangeLinearGauge!.length; i++) {
+        if (value! >= rangeLinearGauge![i].start &&
+            value <= rangeLinearGauge![i].end) {
+          return rangeLinearGauge![i].color;
+        }
+      }
+      // Return a default style if no range color is found
+      return getTextStyle.color;
+    }
+
     final ui.TextStyle labelTextStyle = ui.TextStyle(
-      color: getTextStyle.color,
+      // color: getTextStyle.color,
+      color: getRangeColor(text),
       fontSize: getTextStyle.fontSize,
       background: getTextStyle.background,
       decoration: getTextStyle.decoration,
@@ -494,14 +511,6 @@ class RenderLinearGauge extends RenderBox {
     double totalWidth = end;
     double percentageInVal = (getValue * 100) / (getEnd);
 
-//todo : create a function for thisx
-    // double calculateValuePixelWidth(double value) {
-    //   double percentInVal = (value * 100) / (getEnd);
-    //   double totalValOnPixel = ((value * percentInVal) / 100) -
-    //       ((value * removeStartPercentage) / 100);
-    //   return totalValOnPixel;
-    // }
-
     double totalValOnPixel = ((totalWidth * percentageInVal) / 100) -
         ((totalWidth * removeStartPercentage) / 100);
 
@@ -554,11 +563,11 @@ class RenderLinearGauge extends RenderBox {
             .createShader(gaugeContainer);
       }
 
-      ///* Normal DrawRect
-      // canvas.drawRect(
-      //   gaugeContainer,
-      //   _linearGaugeContainerValuePaint,
-      // );
+      // ValueContainer for Linear-Gauge
+      canvas.drawRect(
+        gaugeContainer,
+        _linearGaugeContainerValuePaint,
+      );
 
       /// For loop for calculating colors in [Linear-Gauge-Color]
       for (int i = 0; i < rangeLinearGauge!.length; i++) {
@@ -585,7 +594,6 @@ class RenderLinearGauge extends RenderBox {
           gaugeContainer,
           _linearGaugeContainerValuePaint,
         );
-        // x += width;
       }
     }
   }

--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -2,11 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:geekyants_flutter_gauges/gauges.dart';
 import 'dart:ui' as ui;
 import 'dart:math' as math;
-
 import 'package:geekyants_flutter_gauges/linear_gauge/linear_gauge_label.dart';
-
-import 'range_linear_gauge/range_linear_gauge.dart';
-// import 'package:geekyants_flutter_gauges/linear_gauge/pointers/linear_gauge_pointer.dart';
 
 class RenderLinearGauge extends RenderBox {
   RenderLinearGauge({
@@ -724,8 +720,6 @@ class RenderLinearGauge extends RenderBox {
         _paintGaugeContainer(canvas, size);
       }
     }
-
-//!    // print(getLinearGaugeIndicator.value);
 
     double value = getLinearGaugeIndicator.value ?? _valueInPixel;
 

--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -512,25 +512,24 @@ class RenderLinearGauge extends RenderBox {
           start, offset.dy, end, getLinearGaugeBoxDecoration.height);
     }
 
-    // get 50 % of total width;
-    double removeStartPercentage = (getStart * 100) / getEnd;
-
     double totalWidth = end;
-    double percentageInVal = (getValue * 100) / (getEnd);
+    double totalValOnPixel;
 
-    double totalValOnPixel = ((totalWidth * percentageInVal) / 100) -
-        ((totalWidth * removeStartPercentage) / 100);
+    if (getValue < getStart) {
+      totalValOnPixel = 0.0;
+    } else {
+      totalValOnPixel =
+          ((getValue - getStart) / (getEnd - getStart)) * totalWidth;
+    }
 
     // if pointer value is null then draw the value in the gauge container
     if (_indicator.getPointerValue == null) {
       _valueInPixel = totalValOnPixel;
     } else {
-      double percentageInValPointer =
-          (_indicator.getPointerValue * 100) / (getEnd);
-      double totalValOnPixelPointer =
-          ((totalWidth * percentageInValPointer) / 100) -
-              ((totalWidth * removeStartPercentage) / 100);
-      _valueInPixel = totalValOnPixelPointer;
+      double pointerValue = _indicator.getPointerValue ?? getValue;
+      double pointerValueInPx =
+          ((pointerValue - getStart) / (getEnd - getStart)) * totalWidth;
+      _valueInPixel = pointerValueInPx;
     }
 
     if (getLinearGaugeBoxDecoration.borderRadius != null) {
@@ -580,8 +579,7 @@ class RenderLinearGauge extends RenderBox {
       for (int i = 0; i < rangeLinearGauge!.length; i++) {
         // Method to cal exact width
         double calculateValuePixelWidth(double value) {
-          return (totalWidth * (value / getEnd)) -
-              ((totalWidth * removeStartPercentage) / 100);
+          return ((value - getStart) / (getEnd - getStart)) * totalWidth;
         }
 
         // Start of the ColorRange
@@ -594,11 +592,9 @@ class RenderLinearGauge extends RenderBox {
                 calculateValuePixelWidth(rangeLinearGauge![i].start);
 
         _linearGaugeContainerValuePaint.color = rangeLinearGauge![i].color;
-        // gaugeContainer = Rect.fromLTWH(colorRangeStart, offset.dy,
-        //     colorRangeWidth, getLinearGaugeBoxDecoration.height);
+        gaugeContainer = Rect.fromLTWH(colorRangeStart, offset.dy,
+            colorRangeWidth, getLinearGaugeBoxDecoration.height);
 
-        gaugeContainer = Rect.fromLTWH(start, offset.dy, totalValOnPixel,
-            getLinearGaugeBoxDecoration.height);
         _linearGaugeContainerValuePaint.color = rangeLinearGauge![i].color;
         canvas.drawRect(
           gaugeContainer,
@@ -746,7 +742,6 @@ class RenderLinearGauge extends RenderBox {
       _indicator.setPointerValue = value;
     }
 
-    print(firstOffset);
     var firstOff = _linearGaugeLabel
             .getPrimaryRulersOffset[getStart.toInt().toString()]![0] +
         firstOffset;

--- a/lib/linear_gauge/pointers/linear_gauge_pointer.dart
+++ b/lib/linear_gauge/pointers/linear_gauge_pointer.dart
@@ -30,7 +30,7 @@ class LinearGaugeIndicator {
     this.height = 10.0,
     this.color = Colors.red,
     this.width = 10.0,
-    required this.shape,
+    this.shape,
   });
 
   ///
@@ -132,7 +132,7 @@ class LinearGaugeIndicator {
   void _drawCirclePointer(
       Canvas canvas, Offset offset, RenderLinearGauge linearGauge) {
     Color indicatorColor = linearGauge.getLinearGaugeIndicator.color!;
-    double height = linearGauge.getLinearGaugeIndicator.height!;
+    // double height = linearGauge.getLinearGaugeIndicator.height!;
     double width = linearGauge.getLinearGaugeIndicator.width!;
     double gaugeheight = linearGauge.getLinearGaugeBoxDecoration.height;
     RulerPosition rulerPosition = linearGauge.rulerPosition;
@@ -199,7 +199,7 @@ class LinearGaugeIndicator {
 
     final position = Offset(offset.dx, offset.dy);
     final path = Path();
-    late double yPos;
+    // late double yPos;
 
     if (rulerPosition == RulerPosition.bottom) {
       path.moveTo(position.dx - (width / 2), -height);
@@ -221,19 +221,14 @@ class LinearGaugeIndicator {
     RenderLinearGauge linearGauge,
   ) {
     Color indicatorColor = linearGauge.getLinearGaugeIndicator.color!;
-    double height = linearGauge.getLinearGaugeIndicator.height!;
+    // double height = linearGauge.getLinearGaugeIndicator.height!;
     double width = linearGauge.getLinearGaugeIndicator.width!;
     double gaugeheight = linearGauge.getLinearGaugeBoxDecoration.height;
     RulerPosition rulerPosition = linearGauge.rulerPosition;
     double primaryRulerHeight = linearGauge.getPrimaryRulersHeight;
 
-    late double yPos;
+    // late double yPos;
 
-    if (rulerPosition == RulerPosition.top) {
-      yPos = -width;
-    } else {
-      yPos = -width;
-    }
     final paint = Paint();
     paint.color = indicatorColor;
 

--- a/lib/linear_gauge/range_linear_gauge/range_linear_gauge.dart
+++ b/lib/linear_gauge/range_linear_gauge/range_linear_gauge.dart
@@ -16,7 +16,7 @@ class RangeLinearGauge {
     required this.color,
     required this.start,
     required this.end,
-  });
+  }) : assert(start < end, 'Start value should be less than end value');
 
   /// `color` Sets the color of the range
   final Color color;


### PR DESCRIPTION
This  PR completes feature  Fixes #23 and also Closes #36 
Changes Made :
<img width="1283" alt="Screenshot 2023-03-02 at 3 39 41 PM" src="https://user-images.githubusercontent.com/50929682/222436461-b85f3173-ca10-495c-a44a-caafb5917d5a.png">

1. Added a method in order to Paint Appropriate colors to the text labels of the `Ruler`

<img width="616" alt="Screenshot 2023-03-02 at 3 20 26 PM" src="https://user-images.githubusercontent.com/50929682/222436633-cf1a5047-6ece-4ada-9bec-a66be027a08d.png">


This method replaces  the default `getTextStyle.color`

2. Made changes to the `paintGaugeContainer` by re-adding the `canvas.drawRect` method as `Valuecontainer` wasn’t getting painted when no `RangeLinearColors` were provided.



1. Added  multiple asserts to in `RangeLinearGauge` to throw error when user inputs the wrong values
2. Fixed an issue where the `pointer` was being shown without being called
3. Removed some `Commented` Lines  and added `Comments` where Necessary

As for #36 , Values where ColorRanges were different than what was mentioned is Fixed
<img width="1434" alt="Screenshot 2023-03-02 at 6 39 31 PM" src="https://user-images.githubusercontent.com/50929682/222437730-9612f4e2-3656-46e0-82e1-4afc37eb33a5.png">
the Above image is the output for the below code
```SizedBox(
              child: LinearGauge(
                  start: 10,
                  end: 50,
                  rulers: const RulerStyle(
                      indicator: LinearGaugeIndicator(
                    shape: PointerShape.triangle,
                  )),
                  rangeLinearGauge: [
                    RangeLinearGauge(color: Colors.blue, start: 10, end: 20),
                    RangeLinearGauge(color: Colors.green, start: 20, end: 30),
                    RangeLinearGauge(color: Colors.orange, start: 30, end: 50),
                  ]),
            ),
 ```