### PR TITLE
range bar for vertical corrected

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/gauge_vertical.dart';
+import 'package:example/range_vertical.dart';
 import 'package:flutter/material.dart';
 import 'package:geekyants_flutter_gauges/gauges.dart';
 import 'package:geekyants_flutter_gauges/linear_gauge/value_bar/value_bar.dart';
@@ -22,6 +23,6 @@ class MyGaugeExample extends StatefulWidget {
 class _MyGaugeExampleState extends State<MyGaugeExample> {
   @override
   Widget build(BuildContext context) {
-    return MyVerticalGauge();
+    return MyVerticalRange();
   }
 }

--- a/example/lib/range_vertical.dart
+++ b/example/lib/range_vertical.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:geekyants_flutter_gauges/gauges.dart';
+
+class MyVerticalRange extends StatefulWidget {
+  const MyVerticalRange({super.key});
+
+  @override
+  State<MyVerticalRange> createState() => _MyVerticalRangeState();
+}
+
+class _MyVerticalRangeState extends State<MyVerticalRange> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: LinearGauge(
+          value: 10,
+          rangeLinearGauge: [
+            RangeLinearGauge(color: Colors.red, start: 10, end: 20),
+            RangeLinearGauge(color: Colors.amber, start: 20, end: 30),
+          ],
+          gaugeOrientation: GaugeOrientation.vertical,
+          rulers: const RulerStyle(
+            rulersOffset: 10,
+            labelOffset: 10,
+            inverseRulers: false,
+            rulerPosition: RulerPosition.center,
+            showLabel: true,
+          ),
+          // customLabels: [
+          //   CustomRulerLabel(text: "10%", value: 10),
+          //   CustomRulerLabel(text: "20%", value: 20),
+          //   CustomRulerLabel(text: "25%", value: 25),
+          //   CustomRulerLabel(text: "30%", value: 30),
+          // ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -747,7 +747,7 @@ class RenderLinearGauge extends RenderBox {
         gaugeContainer = Rect.fromLTWH(
           offset.dy,
           !getInversedRulers ? (start + end) : start,
-          getLinearGaugeBoxDecoration.height,
+          getLinearGaugeBoxDecoration.width,
           !getInversedRulers ? -totalValOnPixel : totalValOnPixel,
         );
       }
@@ -783,18 +783,31 @@ class RenderLinearGauge extends RenderBox {
 
         // Start of the ColorRange
 
-        double colorRangeStart = !getInversedRulers
-            ? (calculateValuePixelWidth(rangeLinearGauge![i].start) + start)
-            : ((start + end) -
-                calculateValuePixelWidth(rangeLinearGauge![i].start));
+        double colorRangeStart;
+        if (getGaugeOrientation == GaugeOrientation.horizontal) {
+          colorRangeStart = !getInversedRulers
+              ? (calculateValuePixelWidth(rangeLinearGauge![i].start) + start)
+              : ((start + end) -
+                  calculateValuePixelWidth(rangeLinearGauge![i].start));
 
-        _linearGaugeContainerValuePaint.color = rangeLinearGauge![i].color;
-        gaugeContainer = Rect.fromLTWH(
-          colorRangeStart,
-          offset.dy,
-          (!getInversedRulers) ? colorRangeWidth : -colorRangeWidth,
-          getLinearGaugeBoxDecoration.height,
-        );
+          gaugeContainer = Rect.fromLTWH(
+            colorRangeStart,
+            offset.dy,
+            !getInversedRulers ? colorRangeWidth : -colorRangeWidth,
+            getLinearGaugeBoxDecoration.height,
+          );
+        } else {
+          colorRangeStart = !getInversedRulers
+              ? ((start + end) -
+                  calculateValuePixelWidth(rangeLinearGauge![i].start))
+              : (calculateValuePixelWidth(rangeLinearGauge![i].start) + start);
+          gaugeContainer = Rect.fromLTWH(
+            offset.dy,
+            colorRangeStart,
+            getLinearGaugeBoxDecoration.width,
+            !getInversedRulers ? -colorRangeWidth : colorRangeWidth,
+          );
+        }
 
         _linearGaugeContainerValuePaint.color = rangeLinearGauge![i].color;
         canvas.drawRect(


### PR DESCRIPTION
fixes #75 

Some little changes in calculation in range container for vertical orientation and now it’s working fine

<img width="190" alt="Screenshot 2023-03-10 at 2 58 00 PM" src="https://user-images.githubusercontent.com/126167018/224279420-46870afa-a90c-413c-b690-505c8617b882.png">

