### PR TITLE
Fix-155

### DIFF
--- a/lib/linear_gauge/linear_gauge_painter.dart
+++ b/lib/linear_gauge/linear_gauge_painter.dart
@@ -794,7 +794,10 @@ class RenderLinearGauge extends RenderBox {
         borderRadius: getLinearGaugeBoxDecoration.borderRadius,
         edgeStyle: getLinearGaugeBoxDecoration.edgeStyle,
       );
-      canvas.drawRRect(rectangularBox, _linearGaugeContainerPaint);
+
+      if (_showLinearGaugeContainer) {
+        canvas.drawRRect(rectangularBox, _linearGaugeContainerPaint);
+      }
 
       _linearGaugeContainerValuePaint.color = getLinearGaugeContainerValueColor;
 
@@ -814,13 +817,15 @@ class RenderLinearGauge extends RenderBox {
         );
       }
 
-      canvas.drawRRect(
-        RRect.fromRectAndRadius(
-          gaugeContainer,
-          Radius.circular(getLinearGaugeBoxDecoration.borderRadius!),
-        ),
-        _linearGaugeContainerValuePaint,
-      );
+      if (_showLinearGaugeContainer) {
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            gaugeContainer,
+            Radius.circular(getLinearGaugeBoxDecoration.borderRadius!),
+          ),
+          _linearGaugeContainerValuePaint,
+        );
+      }
 
       _drawValueBars(
         canvas: canvas,
@@ -837,7 +842,9 @@ class RenderLinearGauge extends RenderBox {
         offset: offset,
       );
     } else {
-      canvas.drawRect(gaugeContainer, _linearGaugeContainerPaint);
+      if (_showLinearGaugeContainer) {
+        canvas.drawRect(gaugeContainer, _linearGaugeContainerPaint);
+      }
 
       _linearGaugeContainerValuePaint.color = getLinearGaugeContainerValueColor;
       if (getGaugeOrientation == GaugeOrientation.horizontal) {
@@ -1190,8 +1197,6 @@ class RenderLinearGauge extends RenderBox {
       Offset a = Offset(x, y);
       _primaryRulersPaint.color = primaryRulerColor!;
 
-
-     
       if (showLabel) {
         _drawLabels(canvas, _linearGaugeLabel.getListOfLabel[count].text!,
             _linearGaugeLabel.getListOfLabel[count].value!, value);
@@ -1624,9 +1629,7 @@ class RenderLinearGauge extends RenderBox {
 
     _calculateRulerPoints();
     if (rulerPosition == RulerPosition.center) {
-      if (getShowLinearGaugeContainer) {
-        _paintGaugeContainer(canvas, size);
-      }
+      _paintGaugeContainer(canvas, size);
     }
 
     _drawPrimaryRulers(canvas);
@@ -1636,9 +1639,7 @@ class RenderLinearGauge extends RenderBox {
     }
 
     if (rulerPosition != RulerPosition.center) {
-      if (getShowLinearGaugeContainer) {
-        _paintGaugeContainer(canvas, size);
-      }
+      _paintGaugeContainer(canvas, size);
     }
 
     var firstOffset = (!getInversedRulers)


### PR DESCRIPTION
Fixes #155 

# Changes 
Moved LinearGaugeContainer If Conditions to paintGaugeContainer Method to Ensure Pointer and Value Bar can access Alignment variables when Container is Disabled.

# explanation
Previously, the pointers and value bar drawings were dependent on the LinearGaugeContainer being enabled, leading to misalignment issues when the container was disabled. To address this problem, I moved the if conditions that check if the container should be drawn or not to inside the paintGaugeContainer method. This ensures that the pointer and value bar can still access their values and are aligned correctly even when the container is disabled. 