### PR TITLE
fix: RangeLinearGauge top

### DIFF
--- a/lib/src/linear_gauge/linear_gauge_painter.dart
+++ b/lib/src/linear_gauge/linear_gauge_painter.dart
@@ -967,9 +967,7 @@ class RenderLinearGauge extends RenderBox {
 
         gaugeContainer = Rect.fromLTWH(
           colorRangeStart,
-          rulerPosition == RulerPosition.top
-              ? size.height - offset.dy - getThickness
-              : offset.dy,
+          offset.dy,
           !getInversedRulers ? colorRangeWidth : -colorRangeWidth,
           getThickness,
         );


### PR DESCRIPTION
# Changes 
Fixes #150 
After the view box change, the gauge no longer sticks to the top, Hence the condition applied before in #151   is not needed 
