### PR TITLE
Fix-Needle gap error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```dart
 dependencies:
-  geekyants_flutter_gauges: 1.0.1
+  geekyants_flutter_gauges: 1.0.2
 ```
 
 ## Usage
@@ -76,6 +76,8 @@ import 'package:geekyants_flutter_gauges/geekyants_flutter_gauges.dart';
 ```
 
 Use it as below
+
+# Linear Gauge usage
 
 ```dart
 class _MyGaugeExampleState extends State<MyGaugeExample> {
@@ -89,6 +91,31 @@ class _MyGaugeExampleState extends State<MyGaugeExample> {
           ),
         ),
       ),
+    );
+  }
+}
+```
+
+# Radial Gauge usage
+
+```dart
+class _MyGaugeExampleState extends State<MyGaugeExample> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: RadialGauge(
+        track: RadialTrack(
+          start: 0,
+          end: 100,
+        ),
+        needlePointer: [
+          NeedlePointer(
+            value: 30,
+            ),
+          ],
+        ),
+      )
     );
   }
 }
@@ -224,3 +251,7 @@ In the Radial Gauge, the `NeedlePointer` and `RadialShapePointer` can be set to 
 ## Credits
 
 Made with ❤️ by <a href="https://geekyants.com/" ><img src="https://s3.ap-southeast-1.amazonaws.com/cdn.elitmus.com/sy0zfezmfdovlb4vaz6siv1l7g30" height="17"/></a>
+
+```
+
+```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,20 +63,12 @@ class _RadialGaugeExampleState extends State<RadialGaugeExample> {
       backgroundColor: Colors.white,
       body: RadialGauge(
         track: RadialTrack(
-            color: Colors.grey,
-            start: 0,
-            end: 100,
-            trackStyle: TrackStyle(
-                showLastLabel: false,
-                secondaryRulerColor: Colors.grey,
-                secondaryRulerPerInterval: 3)),
+          start: 0,
+          end: 100,
+        ),
         needlePointer: [
           NeedlePointer(
             value: 30,
-            color: Colors.red,
-            tailColor: Colors.black,
-            tailRadius: 0,
-            needleStyle: NeedleStyle.flatNeedle,
           ),
         ],
       ),

--- a/lib/src/radial_gauge/pointer/needle_pointer_painter.dart
+++ b/lib/src/radial_gauge/pointer/needle_pointer_painter.dart
@@ -198,6 +198,7 @@ class RenderNeedlePointer extends RenderBox {
 
     final needlePaint = Paint()
       ..color = _color
+      ..style = PaintingStyle.fill
       ..strokeWidth = strokeWidth
       ..shader = gradient.createShader(
         Rect.fromPoints(


### PR DESCRIPTION
# Changes 
- Fixed an issue where Needle was breaking in mobile browsers (Noticed in showcase app)
- Changed `Readme` version to 1.0.2 and Added RadialGauge example 
<img width="1022" alt="Screenshot 2023-07-28 at 12 47 12 PM" src="https://github.com/GeekyAnts/GaugesFlutter/assets/50929682/4f17d172-5d33-43fa-a55c-1c49959b0d53">
<img width="899" alt="Screenshot 2023-07-28 at 12 47 50 PM" src="https://github.com/GeekyAnts/GaugesFlutter/assets/50929682/db95fcc6-77d9-4909-892e-3ea3b3b2d172">
<img width="913" alt="Screenshot 2023-07-28 at 12 47 34 PM" src="https://github.com/GeekyAnts/GaugesFlutter/assets/50929682/f7c159df-5074-432b-b1bc-b07a5e077955">

