### PR TITLE
Feature: Number Formatter 

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,8 +36,8 @@ class _LinearGaugeExampleState extends State<LinearGaugeExample> {
         child: Column(
           children: [
             LinearGauge(
-              numberFormat:
-                  NumberFormat.currency(decimalDigits: 1, symbol: 'F'),
+              // numberFormat:
+              //     NumberFormat.currency(decimalDigits: 1, symbol: 'F'),
               start: -70.33,
               end: 62.4444,
               gaugeOrientation: GaugeOrientation.horizontal,
@@ -70,29 +70,34 @@ class _LinearGaugeExampleState extends State<LinearGaugeExample> {
 /// You can customize the [RadialGauge] Widget as per your need.
 ///
 
-// class RadialGaugeExample extends StatefulWidget {
-//   const RadialGaugeExample({super.key});
+class RadialGaugeExample extends StatefulWidget {
+  const RadialGaugeExample({super.key});
 
-//   @override
-//   State<RadialGaugeExample> createState() => _RadialGaugeExampleState();
-// }
+  @override
+  State<RadialGaugeExample> createState() => _RadialGaugeExampleState();
+}
 
-// class _RadialGaugeExampleState extends State<RadialGaugeExample> {
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       backgroundColor: Colors.white,
-//       body: RadialGauge(
-//         track: RadialTrack(
-//           start: 0,
-//           end: 100,
-//         ),
-//         needlePointer: [
-//           NeedlePointer(
-//             value: 30,
-//           ),
-//         ],
-//       ),
-//     );
-//   }
-// }
+class _RadialGaugeExampleState extends State<RadialGaugeExample> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: RadialGauge(
+        track: RadialTrack(
+          // trackLabelFormater: (value) {
+          //   return NumberFormat.currency(
+          //           locale: 'en_US', name: 'R', decimalDigits: 3)
+          //       .format(value);
+          // },
+          start: -70.33,
+          end: 62.4444,
+        ),
+        needlePointer: [
+          NeedlePointer(
+            value: 30,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:example/gauge_vertical.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:geekyants_flutter_gauges/geekyants_flutter_gauges.dart';
+// import 'package:syncfusion_flutter_gauges/gauges.dart';
+import 'package:intl/intl.dart';
 
 void main() {
   runApp(
     const MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: MyVerticalGauge(),
+      home: LinearGaugeExample(),
     ),
   );
 }
@@ -23,21 +26,38 @@ class LinearGaugeExample extends StatefulWidget {
 }
 
 class _LinearGaugeExampleState extends State<LinearGaugeExample> {
+  NumberFormat formatter =
+      NumberFormat.currency(locale: 'en_US', name: 'Rupees');
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: LinearGauge(
-          gaugeOrientation: GaugeOrientation.horizontal,
-          enableGaugeAnimation: true,
-          rulers: RulerStyle(
-            rulerPosition: RulerPosition.bottom,
-          ),
-          pointers: const [
-            Pointer(
-              value: 50,
-              shape: PointerShape.circle,
+        child: Column(
+          children: [
+            LinearGauge(
+              numberFormat:
+                  NumberFormat.currency(decimalDigits: 1, symbol: 'F'),
+              start: -70.33,
+              end: 62.4444,
+              gaugeOrientation: GaugeOrientation.horizontal,
+              enableGaugeAnimation: true,
+              rulers: RulerStyle(
+                rulerPosition: RulerPosition.bottom,
+              ),
+              pointers: const [
+                Pointer(
+                  value: 50,
+                  shape: PointerShape.circle,
+                ),
+              ],
             ),
+            // SfLinearGauge(
+            //   showAxisTrack: true,
+            //   minimum: -70.333333,
+            //   numberFormat: NumberFormat.currency(decimalDigits: 1, symbol: ''),
+            //   maximum: 62.4,
+            // )
           ],
         ),
       ),
@@ -50,29 +70,29 @@ class _LinearGaugeExampleState extends State<LinearGaugeExample> {
 /// You can customize the [RadialGauge] Widget as per your need.
 ///
 
-class RadialGaugeExample extends StatefulWidget {
-  const RadialGaugeExample({super.key});
+// class RadialGaugeExample extends StatefulWidget {
+//   const RadialGaugeExample({super.key});
 
-  @override
-  State<RadialGaugeExample> createState() => _RadialGaugeExampleState();
-}
+//   @override
+//   State<RadialGaugeExample> createState() => _RadialGaugeExampleState();
+// }
 
-class _RadialGaugeExampleState extends State<RadialGaugeExample> {
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      backgroundColor: Colors.white,
-      body: RadialGauge(
-        track: RadialTrack(
-          start: 0,
-          end: 100,
-        ),
-        needlePointer: [
-          NeedlePointer(
-            value: 30,
-          ),
-        ],
-      ),
-    );
-  }
-}
+// class _RadialGaugeExampleState extends State<RadialGaugeExample> {
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       backgroundColor: Colors.white,
+//       body: RadialGauge(
+//         track: RadialTrack(
+//           start: 0,
+//           end: 100,
+//         ),
+//         needlePointer: [
+//           NeedlePointer(
+//             value: 30,
+//           ),
+//         ],
+//       ),
+//     );
+//   }
+// }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.3"
+    version: "1.0.4"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/src/linear_gauge/gauge_container/linear_gauge_container.dart
+++ b/lib/src/linear_gauge/gauge_container/linear_gauge_container.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:geekyants_flutter_gauges/geekyants_flutter_gauges.dart';
+import 'package:intl/intl.dart';
 import 'dart:math' as math;
 import '../linear_gauge_label.dart';
 
@@ -19,6 +20,7 @@ class LinearGaugeContainer extends LeafRenderObjectWidget {
     return RenderLinearGaugeContainer(
         start: linearGauge.start!,
         end: linearGauge.end!,
+        numberFormat: linearGauge.numberFormat ?? NumberFormat('#.##'),
         value: linearGauge.value!,
         steps: linearGauge.steps!,
         gaugeOrientation: linearGauge.gaugeOrientation!,
@@ -59,6 +61,7 @@ class LinearGaugeContainer extends LeafRenderObjectWidget {
     renderObject
       ..setStart = linearGauge.start!
       ..setEnd = linearGauge.end!
+      ..setNumberFormat = linearGauge.numberFormat ?? NumberFormat('#.##')
       ..setValue = linearGauge.value!
       ..setSteps = linearGauge.steps!
       ..setGaugeOrientation = linearGauge.gaugeOrientation!
@@ -98,6 +101,7 @@ class RenderLinearGaugeContainer extends RenderBox {
   RenderLinearGaugeContainer({
     required double start,
     required double end,
+    required NumberFormat numberFormat,
     required double steps,
     required double value,
     required GaugeOrientation gaugeOrientation,
@@ -130,6 +134,7 @@ class RenderLinearGaugeContainer extends RenderBox {
     required LinearGradient? linearGradient,
   })  : _start = start,
         _end = end,
+        _numberFormat = numberFormat,
         _value = value,
         _steps = steps,
         _gaugeOrientation = gaugeOrientation,
@@ -181,6 +186,7 @@ class RenderLinearGaugeContainer extends RenderBox {
   set setStart(double start) {
     if (_start == start) return;
     _start = start;
+    // _start = double.parse(start.toStringAsFixed(2));
     markNeedsPaint();
   }
 
@@ -202,6 +208,14 @@ class RenderLinearGaugeContainer extends RenderBox {
       return;
     }
     _value = val;
+    markNeedsPaint();
+  }
+
+  NumberFormat get getNumberFormat => _numberFormat ?? NumberFormat('#.##');
+  NumberFormat? _numberFormat;
+  set setNumberFormat(NumberFormat? numberFormat) {
+    if (_numberFormat == numberFormat) return;
+    _numberFormat = numberFormat;
     markNeedsPaint();
   }
 
@@ -700,6 +714,7 @@ class RenderLinearGaugeContainer extends RenderBox {
       }
 
       _linearGaugeLabel.addLabels(
+        numberFormat: getNumberFormat,
         distanceValueInRangeOfHundred: getSteps == 0.0 ? interval : getSteps,
         start: getStart,
         end: getEnd,

--- a/lib/src/linear_gauge/gauge_container/linear_gauge_container.dart
+++ b/lib/src/linear_gauge/gauge_container/linear_gauge_container.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:geekyants_flutter_gauges/geekyants_flutter_gauges.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' show NumberFormat;
 import 'dart:math' as math;
 import '../linear_gauge_label.dart';
 
@@ -20,7 +20,7 @@ class LinearGaugeContainer extends LeafRenderObjectWidget {
     return RenderLinearGaugeContainer(
         start: linearGauge.start!,
         end: linearGauge.end!,
-        numberFormat: linearGauge.numberFormat ?? NumberFormat('#.##'),
+        numberFormat: linearGauge.labelFormat ?? NumberFormat('#.##'),
         value: linearGauge.value!,
         steps: linearGauge.steps!,
         gaugeOrientation: linearGauge.gaugeOrientation!,
@@ -61,7 +61,7 @@ class LinearGaugeContainer extends LeafRenderObjectWidget {
     renderObject
       ..setStart = linearGauge.start!
       ..setEnd = linearGauge.end!
-      ..setNumberFormat = linearGauge.numberFormat ?? NumberFormat('#.##')
+      ..setNumberFormat = linearGauge.labelFormat ?? NumberFormat('#.##')
       ..setValue = linearGauge.value!
       ..setSteps = linearGauge.steps!
       ..setGaugeOrientation = linearGauge.gaugeOrientation!
@@ -714,7 +714,7 @@ class RenderLinearGaugeContainer extends RenderBox {
       }
 
       _linearGaugeLabel.addLabels(
-        numberFormat: getNumberFormat,
+        labelFormat: getNumberFormat,
         distanceValueInRangeOfHundred: getSteps == 0.0 ? interval : getSteps,
         start: getStart,
         end: getEnd,

--- a/lib/src/linear_gauge/linear_gauge.dart
+++ b/lib/src/linear_gauge/linear_gauge.dart
@@ -7,6 +7,7 @@ import 'package:geekyants_flutter_gauges/src/linear_gauge/rulers/label_painter.d
 import 'package:geekyants_flutter_gauges/src/linear_gauge/rulers/rulers.dart';
 import 'package:geekyants_flutter_gauges/src/linear_gauge/rulers/rulers_painter.dart';
 import 'package:geekyants_flutter_gauges/src/linear_gauge/value_bar/valuebar_painter.dart';
+import 'package:intl/intl.dart' show NumberFormat;
 import 'linear_gauge_painter.dart';
 
 /// Creates a LinearGauge Widget to display the values in a linear scale. The
@@ -44,6 +45,7 @@ class LinearGauge extends StatefulWidget {
     Key? key,
     this.start = 0,
     this.end = 100,
+    this.numberFormat,
     this.steps = 0,
     @Deprecated('Use ValueBar instead') this.value = 0,
     this.gaugeOrientation = GaugeOrientation.horizontal,
@@ -154,6 +156,9 @@ class LinearGauge extends StatefulWidget {
   /// ```
   ///
   final double? steps;
+
+  //!
+  final NumberFormat? numberFormat;
 
   ///
   /// `extendLinearGauge` Sets the rulers & labels away from the ending points of [LinearGauge] Container
@@ -712,6 +717,7 @@ class _RLinearGauge extends MultiChildRenderObjectWidget {
     return RenderLinearGauge(
       start: lGauge.start!,
       end: lGauge.end!,
+      numberFormat: lGauge.numberFormat ?? NumberFormat('#.##'),
       steps: lGauge.steps!,
       gaugeOrientation: lGauge.gaugeOrientation!,
       primaryRulersWidth: lGauge.rulers!.primaryRulersWidth!,
@@ -741,6 +747,7 @@ class _RLinearGauge extends MultiChildRenderObjectWidget {
       BuildContext context, RenderLinearGauge renderObject) {
     renderObject
       ..setCustomLabels = lGauge.customLabels!
+      ..setNumberFormat = lGauge.numberFormat!
       ..setGaugeOrientation = lGauge.gaugeOrientation!
       ..setPrimaryRulersHeight = lGauge.rulers!.primaryRulersHeight!
       ..setPrimaryRulersWidth = lGauge.rulers!.primaryRulersWidth!

--- a/lib/src/linear_gauge/linear_gauge.dart
+++ b/lib/src/linear_gauge/linear_gauge.dart
@@ -45,7 +45,7 @@ class LinearGauge extends StatefulWidget {
     Key? key,
     this.start = 0,
     this.end = 100,
-    this.numberFormat,
+    this.labelFormat,
     this.steps = 0,
     @Deprecated('Use ValueBar instead') this.value = 0,
     this.gaugeOrientation = GaugeOrientation.horizontal,
@@ -157,8 +157,18 @@ class LinearGauge extends StatefulWidget {
   ///
   final double? steps;
 
-  //!
-  final NumberFormat? numberFormat;
+  ///
+  /// `labelFormat` Sets the format of the label of the [LinearGauge] using [NumberFormat]
+  ///
+  /// default is to `NumberFormat('#.##')`
+  ///
+  /// ```dart
+  /// const LinearGauge(
+  ///   labelFormat : NumberFormat.currency(locale: "en_US", symbol: "\$"),
+  /// ),
+  /// ```
+  ///
+  final NumberFormat? labelFormat;
 
   ///
   /// `extendLinearGauge` Sets the rulers & labels away from the ending points of [LinearGauge] Container
@@ -717,7 +727,7 @@ class _RLinearGauge extends MultiChildRenderObjectWidget {
     return RenderLinearGauge(
       start: lGauge.start!,
       end: lGauge.end!,
-      numberFormat: lGauge.numberFormat ?? NumberFormat('#.##'),
+      labelFormat: lGauge.labelFormat ?? NumberFormat('#.##'),
       steps: lGauge.steps!,
       gaugeOrientation: lGauge.gaugeOrientation!,
       primaryRulersWidth: lGauge.rulers!.primaryRulersWidth!,
@@ -747,7 +757,7 @@ class _RLinearGauge extends MultiChildRenderObjectWidget {
       BuildContext context, RenderLinearGauge renderObject) {
     renderObject
       ..setCustomLabels = lGauge.customLabels!
-      ..setNumberFormat = lGauge.numberFormat!
+      ..setNumberFormat = lGauge.labelFormat ?? NumberFormat('#.##')
       ..setGaugeOrientation = lGauge.gaugeOrientation!
       ..setPrimaryRulersHeight = lGauge.rulers!.primaryRulersHeight!
       ..setPrimaryRulersWidth = lGauge.rulers!.primaryRulersWidth!

--- a/lib/src/linear_gauge/linear_gauge_label.dart
+++ b/lib/src/linear_gauge/linear_gauge_label.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:geekyants_flutter_gauges/geekyants_flutter_gauges.dart';
 import 'package:geekyants_flutter_gauges/src/linear_gauge/gauge_container/linear_gauge_container.dart';
 import 'package:geekyants_flutter_gauges/src/linear_gauge/rulers/rulers_painter.dart';
+import 'package:intl/intl.dart' show NumberFormat;
 
 class LinearGaugeLabel {
   String? text;
@@ -18,6 +19,7 @@ class LinearGaugeLabel {
       TextPainter(textDirection: TextDirection.ltr);
 
   void addLabels({
+    NumberFormat? numberFormat,
     required double distanceValueInRangeOfHundred,
     required double start,
     required double end,
@@ -25,7 +27,15 @@ class LinearGaugeLabel {
     _linearGaugeLabel.clear();
 
     for (double i = start; i <= end; i += distanceValueInRangeOfHundred) {
-      _linearGaugeLabel.add(LinearGaugeLabel(text: i.toString(), value: i));
+      String temp;
+      if (numberFormat != null) {
+        temp = numberFormat.format(i);
+      } else {
+        temp = i.toString();
+      }
+      _linearGaugeLabel.add(LinearGaugeLabel(text: temp, value: i));
+      // _linearGaugeLabel
+      //     .add(LinearGaugeLabel(text: i.toStringAsFixed(2), value: i));
     }
 
     final LinearGaugeLabel localLabel =

--- a/lib/src/linear_gauge/linear_gauge_label.dart
+++ b/lib/src/linear_gauge/linear_gauge_label.dart
@@ -19,7 +19,7 @@ class LinearGaugeLabel {
       TextPainter(textDirection: TextDirection.ltr);
 
   void addLabels({
-    NumberFormat? numberFormat,
+    NumberFormat? labelFormat,
     required double distanceValueInRangeOfHundred,
     required double start,
     required double end,
@@ -27,21 +27,25 @@ class LinearGaugeLabel {
     _linearGaugeLabel.clear();
 
     for (double i = start; i <= end; i += distanceValueInRangeOfHundred) {
-      String temp;
-      if (numberFormat != null) {
-        temp = numberFormat.format(i);
+      String stringValue;
+      if (labelFormat != null) {
+        stringValue = labelFormat.format(i);
       } else {
-        temp = i.toString();
+        stringValue = i.toString();
       }
-      _linearGaugeLabel.add(LinearGaugeLabel(text: temp, value: i));
-      // _linearGaugeLabel
-      //     .add(LinearGaugeLabel(text: i.toStringAsFixed(2), value: i));
+      _linearGaugeLabel.add(LinearGaugeLabel(text: stringValue, value: i));
     }
 
     final LinearGaugeLabel localLabel =
         _linearGaugeLabel[_linearGaugeLabel.length - 1];
     if (localLabel.value != end && localLabel.value! < end) {
-      _linearGaugeLabel.add(LinearGaugeLabel(text: end.toString(), value: end));
+      String stringValue;
+      if (labelFormat != null) {
+        stringValue = labelFormat.format(end);
+      } else {
+        stringValue = end.toString();
+      }
+      _linearGaugeLabel.add(LinearGaugeLabel(text: stringValue, value: end));
     }
   }
 

--- a/lib/src/linear_gauge/linear_gauge_painter.dart
+++ b/lib/src/linear_gauge/linear_gauge_painter.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:geekyants_flutter_gauges/geekyants_flutter_gauges.dart';
@@ -7,6 +9,7 @@ import 'package:geekyants_flutter_gauges/src/linear_gauge/linear_gauge_label.dar
 import 'package:geekyants_flutter_gauges/src/linear_gauge/rulers/label_painter.dart';
 import 'package:geekyants_flutter_gauges/src/linear_gauge/rulers/rulers_painter.dart';
 import 'package:geekyants_flutter_gauges/src/linear_gauge/value_bar/valuebar_painter.dart';
+import 'package:intl/intl.dart' show NumberFormat;
 
 import 'gauge_container/linear_gauge_container.dart';
 
@@ -18,6 +21,7 @@ class RenderLinearGauge extends RenderBox
   RenderLinearGauge({
     required double start,
     required double end,
+    required NumberFormat numberFormat,
     required double steps,
     required GaugeOrientation gaugeOrientation,
     required TextStyle textStyle,
@@ -143,6 +147,8 @@ class RenderLinearGauge extends RenderBox
   double get getStart => _start;
   double _start;
   set setStart(double start) {
+    log('Setting start as $start');
+
     if (_start == start) return;
     _start = start;
     markNeedsPaint();
@@ -156,6 +162,14 @@ class RenderLinearGauge extends RenderBox
   set setEnd(end) {
     if (_end == end) return;
     _end = end;
+    markNeedsPaint();
+  }
+
+  get getNumberFormat => _numberFormat;
+  NumberFormat? _numberFormat;
+  set setNumberFormat(NumberFormat? numberFormat) {
+    if (_numberFormat == numberFormat) return;
+    _numberFormat = numberFormat;
     markNeedsPaint();
   }
 

--- a/lib/src/linear_gauge/linear_gauge_painter.dart
+++ b/lib/src/linear_gauge/linear_gauge_painter.dart
@@ -21,7 +21,7 @@ class RenderLinearGauge extends RenderBox
   RenderLinearGauge({
     required double start,
     required double end,
-    required NumberFormat numberFormat,
+    required NumberFormat labelFormat,
     required double steps,
     required GaugeOrientation gaugeOrientation,
     required TextStyle textStyle,
@@ -147,8 +147,6 @@ class RenderLinearGauge extends RenderBox
   double get getStart => _start;
   double _start;
   set setStart(double start) {
-    log('Setting start as $start');
-
     if (_start == start) return;
     _start = start;
     markNeedsPaint();
@@ -165,11 +163,11 @@ class RenderLinearGauge extends RenderBox
     markNeedsPaint();
   }
 
-  get getNumberFormat => _numberFormat;
-  NumberFormat? _numberFormat;
-  set setNumberFormat(NumberFormat? numberFormat) {
-    if (_numberFormat == numberFormat) return;
-    _numberFormat = numberFormat;
+  get getLabelFormat => _labelFormat;
+  NumberFormat? _labelFormat;
+  set setNumberFormat(NumberFormat? labelFormat) {
+    if (_labelFormat == labelFormat) return;
+    _labelFormat = labelFormat;
     markNeedsPaint();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Description 
The Linear Gauge in the package lacks a built-in number formatter, as highlighted in [this issue](https://github.com/GeekyAnts/GaugesFlutter/issues/255).Also the  basic formatting breaks when numbers with weird values are given 
```dart
LinearGauge(
          start: -70.33,
          end: 62.4444,
          gaugeOrientation: GaugeOrientation.horizontal,
          enableGaugeAnimation: true,
          rulers: RulerStyle(
            rulerPosition: RulerPosition.bottom,
          ),
          pointers: const [
            Pointer(
              value: 50,
              shape: PointerShape.circle,
            ),
          ],
        ),
  ```
![image](https://github.com/GeekyAnts/GaugesFlutter/assets/50929682/9247806f-f9aa-4414-bab2-231b35b5c8d5)

 To address this, we have used  the [intl](https://pub.dev/packages/intl) package's [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) as a parameter. User will able to pass the `numberformat` and change the values as desired, by default the `numberformat` parameter Defaults to `NumberFormat('#.##')`.
 
![image](https://github.com/GeekyAnts/GaugesFlutter/assets/50929682/e8c4f7fd-1a2e-4315-93f1-21c085833621)
