### PR TITLE
Custom Label Format

### DIFF
--- a/lib/src/linear_gauge/pointers/linear_gauge_shape_pointer.dart
+++ b/lib/src/linear_gauge/pointers/linear_gauge_shape_pointer.dart
@@ -40,6 +40,7 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
     this.animationDuration = 1000,
     this.animationType = Curves.ease,
     this.enableAnimation = true,
+    this.labelFormatter,
   }) : super(key: key);
 
   ///
@@ -140,6 +141,19 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
   /// default is to `true`
   ///
   final bool showLabel;
+
+  ///
+  /// `labelFormatter` formats a custom label for the pointer on the [Pointer]
+  ///
+  /// E.g., Value with %
+  /// ```dart
+  /// const LinearGauge(
+  ///  pointer: Pointer(
+  ///    labelFormatter: (double? value) => '$value%',
+  ///  ),
+  /// ),
+  /// ```
+  final String Function(double? value)? labelFormatter;
 
   ///
   /// `quarterTurns` Sets the rotation of the label of `pointer`
@@ -250,23 +264,25 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
   RenderObject createRenderObject(BuildContext context) {
     final LinearGaugeState linearGaugeScope = LinearGaugeState.of(context);
     return RenderLinearGaugeShapePointer(
-        value: value,
-        color: color,
-        width: width,
-        isInteractive: isInteractive,
-        height: height,
-        pointerPosition: pointerPosition,
-        shape: shape,
-        pointerAlignment: pointerAlignment,
-        animationDuration: animationDuration,
-        showLabel: showLabel,
-        animationType: animationType,
-        quarterTurns: quarterTurns,
-        enableAnimation: enableAnimation,
-        labelStyle: labelStyle,
-        onChanged: onChanged,
-        pointerAnimation: linearGaugeScope.animation!,
-        linearGauge: linearGaugeScope.lGauge);
+      value: value,
+      color: color,
+      width: width,
+      isInteractive: isInteractive,
+      height: height,
+      pointerPosition: pointerPosition,
+      shape: shape,
+      pointerAlignment: pointerAlignment,
+      animationDuration: animationDuration,
+      showLabel: showLabel,
+      animationType: animationType,
+      quarterTurns: quarterTurns,
+      enableAnimation: enableAnimation,
+      labelStyle: labelStyle,
+      onChanged: onChanged,
+      pointerAnimation: linearGaugeScope.animation!,
+      linearGauge: linearGaugeScope.lGauge,
+      labelFormatter: labelFormatter,
+    );
   }
 
   @override
@@ -289,7 +305,8 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
       ..setLinearGAuge = linearGaugeScope.lGauge
       ..onChanged = onChanged
       ..setIsInteractive = isInteractive
-      ..setLabelStyle = labelStyle;
+      ..setLabelStyle = labelStyle
+      ..setLabelFormatter = labelFormatter;
 
     super.updateRenderObject(context, renderObject);
   }


### PR DESCRIPTION
Added custom label formatter so that the user can customise how the label appears on the gauge.
https://github.com/GeekyAnts/GaugesFlutter/issues/280 Linked to the first part of this issue.

Example usage:
```
 const LinearGauge(
  pointer: Pointer(
    labelFormatter: (double? value) => '$value%',
  ),
 ),
```

I have not updated the pubspec.yaml versioning in this PR in case you have some other changes you want to bundle in with the next release. If you wish for me to do that I can. Additionally, any questions about the PR or any futher changes you wish me to make, please let me know. 