### PR TITLE
Feat: Add support for a border around the circular radial shape pointer

### DIFF
--- a/lib/src/linear_gauge/pointers/linear_gauge_shape_pointer.dart
+++ b/lib/src/linear_gauge/pointers/linear_gauge_shape_pointer.dart
@@ -40,6 +40,7 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
     this.animationDuration = 1000,
     this.animationType = Curves.ease,
     this.enableAnimation = true,
+    this.labelFormatter,
   }) : super(key: key);
 
   ///
@@ -140,6 +141,19 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
   /// default is to `true`
   ///
   final bool showLabel;
+
+  ///
+  /// `labelFormatter` formats a custom label for the pointer on the [Pointer]
+  ///
+  /// E.g., Value with %
+  /// ```dart
+  /// const LinearGauge(
+  ///  pointer: Pointer(
+  ///    labelFormatter: (double? value) => '$value%',
+  ///  ),
+  /// ),
+  /// ```
+  final String Function(double? value)? labelFormatter;
 
   ///
   /// `quarterTurns` Sets the rotation of the label of `pointer`
@@ -250,23 +264,25 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
   RenderObject createRenderObject(BuildContext context) {
     final LinearGaugeState linearGaugeScope = LinearGaugeState.of(context);
     return RenderLinearGaugeShapePointer(
-        value: value,
-        color: color,
-        width: width,
-        isInteractive: isInteractive,
-        height: height,
-        pointerPosition: pointerPosition,
-        shape: shape,
-        pointerAlignment: pointerAlignment,
-        animationDuration: animationDuration,
-        showLabel: showLabel,
-        animationType: animationType,
-        quarterTurns: quarterTurns,
-        enableAnimation: enableAnimation,
-        labelStyle: labelStyle,
-        onChanged: onChanged,
-        pointerAnimation: linearGaugeScope.animation!,
-        linearGauge: linearGaugeScope.lGauge);
+      value: value,
+      color: color,
+      width: width,
+      isInteractive: isInteractive,
+      height: height,
+      pointerPosition: pointerPosition,
+      shape: shape,
+      pointerAlignment: pointerAlignment,
+      animationDuration: animationDuration,
+      showLabel: showLabel,
+      animationType: animationType,
+      quarterTurns: quarterTurns,
+      enableAnimation: enableAnimation,
+      labelStyle: labelStyle,
+      onChanged: onChanged,
+      pointerAnimation: linearGaugeScope.animation!,
+      linearGauge: linearGaugeScope.lGauge,
+      labelFormatter: labelFormatter,
+    );
   }
 
   @override
@@ -289,7 +305,8 @@ class Pointer extends LeafRenderObjectWidget implements BasePointer {
       ..setLinearGAuge = linearGaugeScope.lGauge
       ..onChanged = onChanged
       ..setIsInteractive = isInteractive
-      ..setLabelStyle = labelStyle;
+      ..setLabelStyle = labelStyle
+      ..setLabelFormatter = labelFormatter;
 
     super.updateRenderObject(context, renderObject);
   }

--- a/lib/src/radial_gauge/pointer/radial_shape_pointer.dart
+++ b/lib/src/radial_gauge/pointer/radial_shape_pointer.dart
@@ -37,6 +37,8 @@ class RadialShapePointer extends LeafRenderObjectWidget {
     this.onChanged,
     this.isInteractive = false,
     this.shape = PointerShape.triangle,
+    this.borderColor,
+    this.borderWidth,
   });
 
   ///
@@ -83,6 +85,18 @@ class RadialShapePointer extends LeafRenderObjectWidget {
   ///
   final PointerShape shape;
 
+  ///
+  /// `borderColor` draws a border around the [RadialShapePointer] on the [RadialGauge]
+  ///  If null, no border is drawn
+  ///
+  final Color? borderColor;
+
+  ///
+  /// `borderWidth` draws a border around the [RadialShapePointer] on the [RadialGauge]
+  ///  If null, no border is drawn
+  ///
+  final double? borderWidth;
+
   @override
   RenderObject createRenderObject(BuildContext context) {
     final RadialGaugeState scope = RadialGaugeState.of(context);
@@ -96,6 +110,8 @@ class RadialShapePointer extends LeafRenderObjectWidget {
       onChanged: onChanged,
       shape: shape,
       radialGauge: scope.rGauge,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
     );
   }
 
@@ -111,6 +127,8 @@ class RadialShapePointer extends LeafRenderObjectWidget {
       ..setWidth = width
       ..onChanged = onChanged
       ..setIsInteractive = isInteractive
-      ..setShape = shape;
+      ..setShape = shape
+      ..setBorderColor = borderColor
+      ..setBorderWidth = borderWidth;
   }
 }

--- a/lib/src/radial_gauge/pointer/radial_shape_pointer_painter.dart
+++ b/lib/src/radial_gauge/pointer/radial_shape_pointer_painter.dart
@@ -14,6 +14,8 @@ class RenderRadialShapePointer extends RenderBox {
     required bool isInteractive,
     required PointerShape shape,
     required RadialGauge radialGauge,
+    required Color? borderColor,
+    required double? borderWidth,
   })  : _value = value,
         _color = color,
         _height = height,
@@ -21,7 +23,9 @@ class RenderRadialShapePointer extends RenderBox {
         _isInteractive = isInteractive,
         _width = width,
         _shape = shape,
-        _radialGauge = radialGauge;
+        _radialGauge = radialGauge,
+        _borderColor = borderColor,
+        _borderWidth = borderWidth;
 
   double _value;
   Color _color;
@@ -29,6 +33,8 @@ class RenderRadialShapePointer extends RenderBox {
   double _width;
   PointerShape _shape;
   RadialGauge _radialGauge;
+  Color? _borderColor;
+  double? _borderWidth;
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
@@ -124,6 +130,22 @@ class RenderRadialShapePointer extends RenderBox {
     markNeedsPaint();
   }
 
+  set setBorderColor(Color? borderColor) {
+    if (_borderColor == borderColor) {
+      return;
+    }
+    _borderColor = borderColor;
+    markNeedsPaint();
+  }
+
+  set setBorderWidth(double? borderWidth) {
+    if (_borderWidth == borderWidth) {
+      return;
+    }
+    _borderWidth = borderWidth;
+    markNeedsPaint();
+  }
+
   late Rect pointerRect;
 
   @override
@@ -182,6 +204,16 @@ class RenderRadialShapePointer extends RenderBox {
         center: Offset(pointerEndX, pointerEndY), radius: _width);
 
     // canvas.drawRect(pointerRect, Paint()..color = _color);
+    if (_borderColor != null && _borderWidth != null) {
+      canvas.drawCircle(
+        Offset(circlePointerEndX, circlePointerEndY),
+        _width + (_borderWidth! / 2),
+        Paint()
+          ..color = _borderColor!
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = _borderWidth!,
+      );
+    }
     canvas.drawCircle(Offset(circlePointerEndX, circlePointerEndY), _width,
         Paint()..color = _color);
     // canvas.drawPath(pointerPath, Paint()..color = _color);


### PR DESCRIPTION
## Feature
This PR adds the ability to specify a border colour and border width for the Radial Pointer, which currently only supports the circle shape.

Example:
<img width="115" alt="Screenshot 2024-12-10 at 20 08 05" src="https://github.com/user-attachments/assets/b497d0ed-6cdf-45d0-b37e-640ce14c6973">

